### PR TITLE
Fix: generateId conditional have to be with length > 0

### DIFF
--- a/src/components/ToDo.js
+++ b/src/components/ToDo.js
@@ -11,7 +11,7 @@ const ToDo = () => {
   const [toDo, setToDo] = useState("");
 
   const generateId = () => {
-    if (list && list.length > 1) {
+    if (list && list.length > 0) {
       return Math.max(...list.map((t) => t.id)) + 1;
     } else {
       return 1;


### PR DESCRIPTION
Hi Sunil, awesome project!

I have found a simple bug in the project. If a user delete all ToDos and create others, the generateID function will create the ID 1 for the two first ToDos.

To solve this, just change the conditional rule to "lenght > 0" =) 

